### PR TITLE
Støtte GCP, oppgradere unleash-client-java, fikse Spring dependency

### DIFF
--- a/pam-unleash-spring/pom.xml
+++ b/pam-unleash-spring/pom.xml
@@ -23,31 +23,32 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.1.3.RELEASE</version>
+            <version>[5.1.3.RELEASE,)</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.28</version>
+            <version>1.7.30</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.13.0</version>
+            <version>2.14.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.0</version>
+            <version>5.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.15.0</version>
+            <version>3.19.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pam-unleash-spring/src/test/java/no/nav/pam/unleash/spring/ConfigurationTest.java
+++ b/pam-unleash-spring/src/test/java/no/nav/pam/unleash/spring/ConfigurationTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigurationTest {
 
-    @EnableUnleash(fakeUnleash = true)
+    @EnableUnleash(fakeUnleash = true, enabledFakeToggles = {"featureFoo"})
     @Configuration
     static class DummyTestConfiguration {
 
@@ -31,6 +31,15 @@ class ConfigurationTest {
 
         ApplicationContext context = new AnnotationConfigApplicationContext(DummyTestConfiguration.class);
         assertThat(context.getBean(Unleash.class)).isInstanceOf(FakeUnleash.class);
+    }
+
+    @Test
+    void that_fake_configuration_enabled_toggles_is_honored() {
+
+        ApplicationContext context = new AnnotationConfigApplicationContext(DummyTestConfiguration.class);
+        Unleash unleash = context.getBean(Unleash.class);
+        assertThat(unleash.isEnabled("featureFoo")).isTrue();
+        assertThat(unleash.isEnabled("featureBar")).isFalse();
     }
 
     @Test

--- a/pam-unleash/pom.xml
+++ b/pam-unleash/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>no.finn.unleash</groupId>
             <artifactId>unleash-client-java</artifactId>
-            <version>3.1.2</version>
+            <version>3.3.4</version>
         </dependency>
     </dependencies>
 

--- a/pam-unleash/src/main/java/no/nav/pam/unleash/IsNotProdStrategy.java
+++ b/pam-unleash/src/main/java/no/nav/pam/unleash/IsNotProdStrategy.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class IsNotProdStrategy implements Strategy {
 
-    private static final List<String> DEFAULT_PROD_ENVIRONMENTS = Arrays.asList( "prod-sbs", "prod-fss", "p");
+    private static final List<String> DEFAULT_PROD_ENVIRONMENTS = Arrays.asList("prod-sbs", "prod-fss", "p", "prod-gcp");
 
     private final boolean isProd;
 


### PR DESCRIPTION
* Støtte GCP for IsNotProdStrategy

* Oppgradere Finn unleash-client-java

* Spring-dependency for pam-unleash-spring:
  Sett scope til 'provided', slik at ikke dette biblioteket legger noen føringer
  på hvilken versjon av Spring-context som dras inn transitivt. Deklarer at
  dette biblioteker støtter versjon 5.1.3 eller nyere av spring-context, men det
  er konsument-appens ansvar å legge til ønsket versjon av Spring-framework som
  avhengighet i bygget.

* Teste fake-unleash enabled-toggles.

* Oppgradere diverse test-avhengigheter.